### PR TITLE
Change deployment environment from 'deploy' to 'Demo-SVV' in Deploy-A…

### DIFF
--- a/.github/workflows/Deploy-AMBA.yml
+++ b/.github/workflows/Deploy-AMBA.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   deploy_job:
     runs-on: ubuntu-latest
-    environment: deploy
+    environment: Demo-SVV
 
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
This pull request includes a change to the deployment environment in the GitHub Actions workflow configuration file. The environment for the `deploy_job` has been updated from `deploy` to `Demo-SVV`.

* [`.github/workflows/Deploy-AMBA.yml`](diffhunk://#diff-4cbade0438a283499968359e4a355dfe7432dc77230093923cefdd27ff6754a5L17-R17): Changed the `environment` value from `deploy` to `Demo-SVV` for the `deploy_job`.